### PR TITLE
Fix compilation.

### DIFF
--- a/plugins/net.danieldietrich.protectedregions.core/pom.xml
+++ b/plugins/net.danieldietrich.protectedregions.core/pom.xml
@@ -37,11 +37,15 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>2.7.1</version>
+				<version>2.7.2</version>
 				<executions>
 					<execution>
 						<id>gensrc</id>
 						<phase>generate-sources</phase>
+						<goals>
+							<goal>compile</goal>
+							<goal>xtend-install-debug-info</goal>
+						</goals>
 						<configuration>
 							<outputDirectory>${basedir}/src/main/xtend-gen</outputDirectory>
 						</configuration>
@@ -49,6 +53,10 @@
 					<execution>
 						<id>gentestsrc</id>
 						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>testCompile</goal>
+							<goal>xtend-test-install-debug-info</goal>
+						</goals>
 						<configuration>
 							<testOutputDirectory>${basedir}/src/test/xtend-gen</testOutputDirectory>
 						</configuration>

--- a/plugins/net.danieldietrich.protectedregions.xtext/pom.xml
+++ b/plugins/net.danieldietrich.protectedregions.xtext/pom.xml
@@ -37,11 +37,15 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>2.7.1</version>
+				<version>2.7.2</version>
 				<executions>
 					<execution>
 						<id>gensrc</id>
 						<phase>generate-sources</phase>
+						<goals>
+							<goal>compile</goal>
+							<goal>xtend-install-debug-info</goal>
+						</goals>
 						<configuration>
 							<outputDirectory>${basedir}/src/main/xtend-gen</outputDirectory>
 						</configuration>
@@ -49,6 +53,10 @@
 					<execution>
 						<id>gentestsrc</id>
 						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>testCompile</goal>
+							<goal>xtend-test-install-debug-info</goal>
+						</goals>
 						<configuration>
 							<testOutputDirectory>${basedir}/src/test/xtend-gen</testOutputDirectory>
 						</configuration>


### PR DESCRIPTION
I noticed that the build using "mvn package" is still broken
in a fresh clone. This should fix it. The update of Xtend
was required, as 2.7.1 threw a ConcurrentModificationException.
